### PR TITLE
Starting webserver requires an explicit argument `httpd`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ For example, if the web logs are `/data/web-logs/access.log-*.gz`:
     docker run --rm -v /data/web-logs:/web-logs:ro -v awstats-db:/var/lib/awstats \
         openmicroscopy/awstats /web-logs/access.log-\*.gz
 
-Run the Awstats web interface by passing no arguments:
+Run the Awstats web interface by passing just `httpd` as an argument:
 
-    docker run --rm -p 8080:8080 -v awstats-db:/var/lib/awstats openmicroscopy/awstats
+    docker run --rm -p 8080:8080 -v awstats-db:/var/lib/awstats openmicroscopy/awstats httpd
 
 Awstats should now be accessible at http://localhost:8080.
 Apache authentication is not enabled.
@@ -54,3 +54,4 @@ For example
 will skip IPs matching `^1\.1\.` `^2\.2\.` in addition to the defaults.
 
 Alternatively you can provide a full configuration by mounting `/etc/awstats` into the container.
+If no logfiles are passed on the command line the `LogFile` configuration option will be used.

--- a/entrypoint.pl
+++ b/entrypoint.pl
@@ -107,7 +107,11 @@ else {
 }
 
 
-if ($log_files) {
+if ($log_files eq 'httpd') {
+    print "Starting httpd awstats\n";
+    exec "/usr/sbin/httpd", "-DFOREGROUND";
+}
+else {
     print "Updating log statistics\n";
     # See /usr/share/awstats/wwwroot/cgi-bin/awstats.pl --help
     my @args = (
@@ -117,12 +121,14 @@ if ($log_files) {
         "-showsteps",
         "-showcorrupted",
         "-showdropped",
-        "-showunknownorigin",
-        "-LogFile=/usr/share/awstats/tools/logresolvemerge.pl $log_files |"
+        "-showunknownorigin"
     );
+    if ($log_files) {
+        # If using an external configuration file it may define LogFile
+        push @args, "-LogFile=/usr/share/awstats/tools/logresolvemerge.pl $log_files |"
+    }
+    else {
+        print "No logfiles on command line, using LogFile from $site_domain configuration file \n"
+    }
     exec @args;
-}
-else {
-    print "No log files provided, starting httpd awstats\n";
-    exec "/usr/sbin/httpd", "-DFOREGROUND";
 }


### PR DESCRIPTION
This is to allow processing with external config files where LogFile is defined.